### PR TITLE
Refactor/configuration

### DIFF
--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,0 +1,9 @@
+module SMSGateway
+    class Configuration
+        attr_accessor :auth_token
+
+        def def initialize
+          @auth_token = nil
+        end
+    end
+end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,9 +1,9 @@
 module SMSGateway
     class Configuration
-        attr_accessor :auth_token
+        attr_accessor :authorization_token
 
         def def initialize
-          @auth_token = nil
+          @authorization_token = nil
         end
     end
 end

--- a/lib/smsgateway.rb
+++ b/lib/smsgateway.rb
@@ -1,19 +1,27 @@
 require 'json'
 require 'api'
-require 'gem_config'
+require 'configuration'
 
 module SMSGateway
-  include GemConfig::Base
 
-  with_configuration do
-    has :authorization_token, classes: String
+  class << self
+    attr_accessor :configuration
   end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
 
   class Message
 
     API_ENDPOINT = 'message/'
 
-    attr_accessor :device_id, :phone_number, :message, :id, :status, :created_at, :updated_at, :log
+    attr_accessor  :device_id, :phone_number, :message, :id, :status, :created_at, :updated_at, :log
 
     def initialize(device_id, phone_number, message, id = nil, status = nil, created_at = nil, updated_at = nil, log = nil)  
       @id           = id

--- a/lib/smsgateway/version.rb
+++ b/lib/smsgateway/version.rb
@@ -1,3 +1,3 @@
 module Smsgateway
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/smsgateway.gemspec
+++ b/smsgateway.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{A ruby gem to interact with smsgateway.me API}
   spec.homepage      = "https://github.com/ashhadsheikh/smsgateway"
   spec.license       = "MIT"
-  spec.files            = ['lib/smsgateway.rb', 'lib/api.rb']
+  spec.files            = ['lib/configuration.rb', 'lib/smsgateway.rb', 'lib/api.rb']
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/smsgateway.gemspec
+++ b/smsgateway.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.license       = 'MIT'
-  spec.add_runtime_dependency 'gem_config'
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
environment variable cannot be used before this. only string can be allowed. this branch will allow string or environment variable to be use as shown below:

```ruby
# config/initializers/smsgateway.rb
SMSGateway.configure do |config|
  config.authorization_token = ENV['AUTH_TOKEN']
end
# or
SMSGateway.configuration.authorization_token = ENV['AUTH_TOKEN']
```